### PR TITLE
Revert "deps: bump notebook from 6.0.3 to 6.1.0 in /docs/Tutorial-PyTorch"

### DIFF
--- a/docs/Tutorial-PyTorch/requirements.txt
+++ b/docs/Tutorial-PyTorch/requirements.txt
@@ -41,7 +41,7 @@ mkl-random==1.1.1
 mkl-service==2.3.0
 nbconvert==5.6.1
 nbformat==5.0.7
-notebook==6.1.0
+notebook==6.0.3
 numpy==1.19.1
 olefile==0.46
 packaging==20.4


### PR DESCRIPTION
Reverts SI-Aizu/documentation#263