### PR TITLE
deps: Add opencv-python headless

### DIFF
--- a/docs/Tutorial-PyTorch/Dockerfile
+++ b/docs/Tutorial-PyTorch/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:1.5.1-cuda10.1-cudnn7-runtime
+FROM pytorch/pytorch:1.6.0-cuda10.1-cudnn7-runtime
 
 ENV PIP_NO_CACHE_DIR="true"
 WORKDIR /build

--- a/docs/Tutorial-PyTorch/Makefile
+++ b/docs/Tutorial-PyTorch/Makefile
@@ -1,5 +1,5 @@
 DOCKER_IMAGE_NAME := docker.pkg.github.com/si-aizu/documentation/pytorch
-DOCKER_TAG := v1.5.1
+DOCKER_TAG := v1.6.0
 DOCKER_CONTAINER_NAME := siaizu_documentation_pytorch
 
 .PHONY: run

--- a/docs/Tutorial-PyTorch/docker-compose.yml
+++ b/docs/Tutorial-PyTorch/docker-compose.yml
@@ -2,11 +2,11 @@ version: '3.2'
 
 services:
   dev:
-    image: 'docker.pkg.github.com/si-aizu/documentation/pytorch:v1.5.1'
+    image: 'docker.pkg.github.com/si-aizu/documentation/pytorch:v1.6.0'
     build:
       context: .
       cache_from:
-        - 'docker.pkg.github.com/si-aizu/documentation/pytorch:v1.5.1'
+        - 'docker.pkg.github.com/si-aizu/documentation/pytorch:v1.6.0'
     container_name: siaizu_documentation_pytorch
     ports:
       - 8000:8000

--- a/docs/Tutorial-PyTorch/requirements.txt
+++ b/docs/Tutorial-PyTorch/requirements.txt
@@ -44,6 +44,8 @@ nbformat==5.0.7
 notebook==6.0.3
 numpy==1.19.1
 olefile==0.46
+opencv-contrib-python-headless==4.3.0.36
+opencv-python-headless==4.3.0.36
 packaging==20.4
 pandocfilters==1.4.2
 parso==0.7.1

--- a/docs/Tutorial-PyTorch/requirements.txt
+++ b/docs/Tutorial-PyTorch/requirements.txt
@@ -1,28 +1,28 @@
+argon2-cffi==20.1.0
 attrs==19.3.0
 backcall==0.2.0
 beautifulsoup4==4.9.1
 bleach==3.1.5
 certifi==2020.6.20
-cffi==1.14.1
+cffi==1.14.0
 chardet==3.0.4
 conda==4.8.3
 conda-build==3.18.11
 conda-package-handling==1.7.0
-cryptography==3.0
+cryptography==2.9.2
 cycler==0.10.0
 decorator==4.4.2
 defusedxml==0.6.0
 entrypoints==0.3
 filelock==3.0.12
-future==0.18.2
 glob2==0.7
 h5py==2.10.0
-idna==2.10
+idna==2.9
 importlib-metadata==1.7.0
 ipykernel==5.3.4
-ipython @ file:///tmp/build/80754af9/ipython_1592348411427/work
+ipython @ file:///tmp/build/80754af9/ipython_1593447368578/work
 ipython-genutils==0.2.0
-jedi==0.17.2
+jedi @ file:///tmp/build/80754af9/jedi_1592841891421/work
 Jinja2==2.11.2
 joblib==0.16.0
 json5==0.9.5
@@ -33,7 +33,7 @@ jupyterlab==2.2.2
 jupyterlab-server==1.2.0
 kiwisolver==1.2.0
 libarchive-c==2.9
-MarkupSafe==1.1.1
+MarkupSafe @ file:///tmp/build/80754af9/markupsafe_1594371495811/work
 matplotlib==3.3.0
 mistune==0.8.4
 mkl-fft==1.1.0
@@ -41,21 +41,22 @@ mkl-random==1.1.1
 mkl-service==2.3.0
 nbconvert==5.6.1
 nbformat==5.0.7
-notebook==6.0.3
-numpy==1.19.1
+notebook==6.1.0
+numpy==1.18.5
 olefile==0.46
 opencv-contrib-python-headless==4.3.0.36
 opencv-python-headless==4.3.0.36
 packaging==20.4
+pandas==1.1.0
 pandocfilters==1.4.2
-parso==0.7.1
-pexpect==4.8.0
-pickleshare==0.7.5
-Pillow==7.1.2
+parso==0.7.0
+pexpect @ file:///tmp/build/80754af9/pexpect_1594383317248/work
+pickleshare @ file:///tmp/build/80754af9/pickleshare_1594384075987/work
+Pillow @ file:///tmp/build/80754af9/pillow_1594307325547/work
 pkginfo==1.5.0.1
 prometheus-client==0.8.0
 prompt-toolkit==3.0.5
-psutil==5.7.2
+psutil==5.7.0
 ptyprocess==0.6.0
 pycosat==0.6.3
 pycparser==2.20
@@ -67,23 +68,24 @@ PySocks==1.7.1
 python-dateutil==2.8.1
 pytz==2020.1
 PyYAML==5.3.1
-pyzmq==19.0.1
-requests==2.24.0
+pyzmq==19.0.2
+requests==2.23.0
 ruamel-yaml==0.15.87
 scikit-learn==0.23.1
 scipy==1.5.2
+seaborn==0.10.1
 Send2Trash==1.5.0
-six==1.15.0
+six==1.14.0
 soupsieve==2.0.1
 terminado==0.8.3
 testpath==0.4.4
 threadpoolctl==2.1.0
 torch==1.6.0
-torchvision==0.6.0a0+35d732a
+torchvision==0.7.0
 tornado==6.0.4
-tqdm==4.48.1
+tqdm==4.46.0
 traitlets==4.3.3
-urllib3==1.25.10
-wcwidth==0.2.5
+urllib3==1.25.8
+wcwidth @ file:///tmp/build/80754af9/wcwidth_1593447189090/work
 webencodings==0.5.1
 zipp==3.1.0


### PR DESCRIPTION
- opencv-python-headless
- opencv-contrib-python-headless

[skvark/opencv-python: Automated CI toolchain to produce precompiled opencv-python, opencv-python-headless, opencv-contrib-python and opencv-contrib-python-headless packages.](https://github.com/skvark/opencv-python)

Close #271