### PR TITLE
Revert "deps: bump peaceiris/mkdocs-material from 2.5.0 to 2.5.1"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   mkdocs:
-    image: peaceiris/mkdocs-material:v2.5.1
+    image: peaceiris/mkdocs-material:v2.5.0
     container_name: siaizu_documentation_mkdocs
     ports:
       - 8888:8888


### PR DESCRIPTION
Reverts SI-Aizu/documentation#270