### PR TITLE
deps: Delete opencv-python

### DIFF
--- a/docs/Tutorial-TensorFlow-Models/Dockerfile
+++ b/docs/Tutorial-TensorFlow-Models/Dockerfile
@@ -55,8 +55,7 @@ WORKDIR /root/build/cocoapi/PythonAPI
 RUN eval "$(~/miniconda/bin/conda shell.bash hook)" && \
     conda activate conda && \
     make && \
-    python3 -m pip install --no-cache-dir pycocotools==2.0.0 && \
-    python3 -m pip install --no-cache-dir opencv-python
+    python3 -m pip install --no-cache-dir pycocotools==2.0.0
 
 COPY .bash_aliases /root/.bash_aliases
 WORKDIR /root/models/research/object_detection_tools


### PR DESCRIPTION
Close #282

特に利用していなかったので、今回は単純に `opencv-python` を削除した。

もし今後再び追加したい時は #271 に従うこと。